### PR TITLE
🔨 vscode: Change markdown ruler to 80

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -3,7 +3,7 @@
         "editor.rulers": [79, 90],
     },
     "[markdown]": {
-        "editor.rulers": [90],
+        "editor.rulers": [80],
     },
     "editor.fontFamily": "Fira Code",
     "editor.fontLigatures": true,


### PR DESCRIPTION
On my native mac screen, I have exactly 85 characters available per pane
when two are open in vertical split. Thus, change this back to 80, so we
don't have to scroll horizontally all the time to get the remaining 5
characters.

For Python (where I'm also using 90) that's not a big problem, as only a
few lines every reach the limit, but for plain text in markdown, this
occurs much more often.