### PR TITLE
➖ dotfiles: Remove aws

### DIFF
--- a/bin/dotfiles.sh
+++ b/bin/dotfiles.sh
@@ -85,7 +85,6 @@ sub_pipx() {
     ln -s ~/.virtualenvs/pipx/bin/pipx ~/bin/ || true
 
     # Install tools with pipx in isolated environments
-    pipx install aws
     pipx install black
     pipx install icdiff
     pipx install flake8


### PR DESCRIPTION
Didn't use that for a long time and just noticed that it's not
compatible to Python 3. There is a new version out which needs some
other setup steps first. So for now, just remove it from pipx.