### PR TITLE
zsh: Remove the git alias

### DIFF
--- a/zsh/.aliases
+++ b/zsh/.aliases
@@ -1,7 +1,6 @@
 alias ls='colorls --gs'
 alias ll='colorls -lA --gs'
 alias ptg='git push origin HEAD:refs/for/master'
-alias git='LANG=en_GB git'
 alias weekly="git log --oneline --author 'Felix' --since=1.weeks --no-merges"
 alias sourcetree='open -a SourceTree ./'
 alias pr='hub pull-request'


### PR DESCRIPTION
This breaks running python in git, e.g. during an interactive rebase by
using
    $ rebase -i master --exec "tox -e linters"

as the locale setting is not fully qualified (the charset is missing).

I once had to overwrite the locale for the git command as it was always
showing the german command output not matter which locale was defined on
the system. By now, it looks like it's not needed anymore, so we are
just fine removing this.