### PR TITLE
git: Enable rerere

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -23,6 +23,9 @@
 [icdiff]
     options = --highlight --line-numbers
 
+[rerere]
+	enabled = true
+
 [alias]
     last = log -1 HEAD
     co = checkout


### PR DESCRIPTION
This caches solved merge conflicts and automatically applies the
solution when the same conflict comes up again. Might come in handy when
rebasing the same stack of changes again and again (which I'm currently
doing most of the time).