### PR TITLE
zsh: Remove "ls" alias for colorls

### DIFF
--- a/zsh/.aliases
+++ b/zsh/.aliases
@@ -1,4 +1,4 @@
-alias ls='colorls --gs'
+#alias ls='colorls --gs'
 alias ll='colorls -lA --gs'
 alias ptg='git push origin HEAD:refs/for/master'
 alias weekly="git log --oneline --author 'Felix' --since=1.weeks --no-merges"


### PR DESCRIPTION
When bootstrapping up a new develment machine or when something is wrong
with colorls (very rarely the case), it's helpful to have at least the
"ls" command still working without having to adapt the zsh config.

Since I'm anyways using the "ll" alias in 99% of the time, it doesn't
harm to switch the ls command back to system defaults.