### PR TITLE
code: Remove badges in tab decorations

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -46,5 +46,6 @@
     ],
     "workbench.editor.wrapTabs": true,
     "workbench.editor.tabSizing": "shrink",
+    "workbench.editor.decorations.badges": false,
     "vsicons.dontShowNewVersionMessage": true
 }


### PR DESCRIPTION
This looks a little cluttered and I find it hard to focus on the active
tab (which is sometimes hard to identify).