### PR TITLE
vscode: Show the commit date in the gitlens inline commit view

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -20,6 +20,7 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,
+    "gitlens.defaultDateSource": "committed",
     "outline.showVariables": false,
     "outline.showModules": false,
     "python.defaultInterpreterPath": "${workspaceFolder}/.tox/dev/bin/python",


### PR DESCRIPTION
In some projects I find it more helpful to directly see when the change
was committed (and thus merged/active) rather than when it was
originally created.

Especially for projects where the roundtrip time of a change is longer.