### PR TITLE
Updates for m1 mac

### DIFF
--- a/.osxdefaults
+++ b/.osxdefaults
@@ -1,9 +1,3 @@
-# ===============
-# === General ===
-# ===============
-
-defaults write -g ApplePressAndHoldEnabled -bool false
-
 # =======================
 # === Finder settings ===
 # =======================
@@ -36,13 +30,6 @@ defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
 # Set mouse pointer speed
 # NOTE: This needs a log off/on or restart to take effect
 defaults write -g com.apple.mouse.scaling 3
-
-# ============
-# === Dock ===
-# ============
-
-# No bouncing icons
-defaults write com.apple.dock no-bouncing -bool true
 
 # ============================================
 # === Kill applications to enable settings ===

--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ ln -s ~/.dotfiles/vscode/settings.json ~/Library/Application\ Support/Code/User/
 ln -s ~/.dotfiles/vscode/keybindings.json ~/Library/Application\ Support/Code/User/keybindings.json
 ```
 
+### Installed Plugins
+
+This is a list of plugins, I've currently installed in vscode:
+
+- Docker
+- GitLens
+- Jupyter
+- Prettier
+- Pylance
+- Python
+- Vim
+- vscode-icons
+
 ## Links
 **iTerm2 color schemes:** https://github.com/mbadolato/iTerm2-Color-Schemes
 **Nerd font for agnoster theme with venv icon:** https://github.com/ryanoasis/nerd-fonts

--- a/iterm2/com.googlecode.iterm2.plist
+++ b/iterm2/com.googlecode.iterm2.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AllowClipboardAccess</key>
+	<true/>
 	<key>AppleAntiAliasingThreshold</key>
 	<integer>1</integer>
 	<key>ApplePressAndHoldEnabled</key>

--- a/iterm2/com.googlecode.iterm2.plist
+++ b/iterm2/com.googlecode.iterm2.plist
@@ -2,18 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>AllowClipboardAccess</key>
-	<true/>
+	<key>AppleAntiAliasingThreshold</key>
+	<integer>1</integer>
+	<key>ApplePressAndHoldEnabled</key>
+	<false/>
+	<key>AppleScrollAnimationEnabled</key>
+	<integer>0</integer>
+	<key>AppleSmoothFixedFontsSizeThreshold</key>
+	<integer>1</integer>
+	<key>AppleWindowTabbingMode</key>
+	<string>manual</string>
 	<key>Default Bookmark Guid</key>
-	<string>629DC2D7-9ACE-46D5-8DBE-9EDFF25B2393</string>
+	<string>4D477FBB-06E5-4E80-8148-926719B230C3</string>
 	<key>HapticFeedbackForEsc</key>
 	<false/>
-	<key>HideScrollbar</key>
-	<true/>
 	<key>HotkeyMigratedFromSingleToMulti</key>
 	<true/>
-	<key>IRMemory</key>
-	<integer>4</integer>
 	<key>New Bookmarks</key>
 	<array>
 		<dict>
@@ -187,7 +191,7 @@
 				<key>Color Space</key>
 				<string>sRGB</string>
 				<key>Green Component</key>
-				<real>0.1491314172744751</real>
+				<real>0.14910027384757996</real>
 				<key>Red Component</key>
 				<real>1</real>
 			</dict>
@@ -230,9 +234,9 @@
 				<key>Color Space</key>
 				<string>sRGB</string>
 				<key>Green Component</key>
-				<real>0.9268307089805603</real>
+				<real>0.92681378126144409</real>
 				<key>Red Component</key>
-				<real>0.70213186740875244</real>
+				<real>0.70214027166366577</real>
 			</dict>
 			<key>Cursor Text Color</key>
 			<dict>
@@ -265,7 +269,7 @@
 				<string>1</string>
 			</dict>
 			<key>Guid</key>
-			<string>629DC2D7-9ACE-46D5-8DBE-9EDFF25B2393</string>
+			<string>4D477FBB-06E5-4E80-8148-926719B230C3</string>
 			<key>Horizontal Spacing</key>
 			<real>1</real>
 			<key>Idle Code</key>
@@ -420,6 +424,8 @@
 					<string></string>
 					<key>Text</key>
 					<string>b</string>
+					<key>Version</key>
+					<integer>0</integer>
 				</dict>
 				<key>0xf703-0x220000</key>
 				<dict>
@@ -450,6 +456,8 @@
 					<string></string>
 					<key>Text</key>
 					<string>f</string>
+					<key>Version</key>
+					<integer>0</integer>
 				</dict>
 				<key>0xf704-0x20000</key>
 				<dict>
@@ -569,11 +577,11 @@
 				<key>Alpha Component</key>
 				<real>1</real>
 				<key>Blue Component</key>
-				<real>0.73423302173614502</real>
+				<real>0.73422712087631226</real>
 				<key>Color Space</key>
 				<string>sRGB</string>
 				<key>Green Component</key>
-				<real>0.35916060209274292</real>
+				<real>0.35915297269821167</real>
 				<key>Red Component</key>
 				<real>0.0</real>
 			</dict>
@@ -648,11 +656,11 @@
 			<key>Window Type</key>
 			<integer>0</integer>
 			<key>Working Directory</key>
-			<string>/Users/q391328</string>
+			<string>/Users/felixedel</string>
 		</dict>
 	</array>
-	<key>PasteTabToStringTabStopSize</key>
-	<integer>4</integer>
+	<key>OpenTmuxWindowsIn</key>
+	<integer>0</integer>
 	<key>PointerActions</key>
 	<dict>
 		<key>Button,1,1,,</key>
@@ -686,8 +694,6 @@
 			<string>kNextWindowPointerAction</string>
 		</dict>
 	</dict>
-	<key>ShowFullScreenTabBar</key>
-	<true/>
 	<key>SoundForEsc</key>
 	<false/>
 	<key>VisualIndicatorForEsc</key>

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -52,4 +52,7 @@
         "jupyter-notebook": "left"
     },
     "zenMode.centerLayout": false,
+    "[html]": {
+        "editor.defaultFormatter": "vscode.html-language-features"
+    },
 }

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -25,7 +25,6 @@
     "gitlens.defaultDateSource": "committed",
     "outline.showVariables": false,
     "outline.showModules": false,
-    "python.defaultInterpreterPath": "${workspaceFolder}/.tox/dev/bin/python",
     "python.formatting.provider": "black",
     "python.formatting.blackPath": "~/.local/bin/black",
     "python.languageServer": "Pylance",

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -33,6 +33,7 @@
     "prettier.jsxSingleQuote": true,
     "search.showLineNumbers": true,
     "vim.statusBarColorControl": true,
+    "window.zoomLevel": 0.5,
     "workbench.settings.editor": "json",
     "workbench.colorCustomizations": {
         "statusBar.background": "#005f5f",

--- a/zsh/.exports
+++ b/zsh/.exports
@@ -1,5 +1,7 @@
 # Define basic path variable
 export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+# Add homebrew ARM binaries to path
+export PATH=/opt/homebrew/bin:${PATH}
 # Add VS Code to the path (binary: code)
 export PATH=/Applications/Visual\ Studio\ Code.app/Contents/Resources/app/bin:${PATH}
 # Add GNU core utils to path (take precedence over FreeBSD commands)


### PR DESCRIPTION
- zsh: Add ARM homebrew binaries to path
- macos: Clean defaults file
- vscode: Remove deprecated python interpreter setting
- vscode: Specify html default formatter
- Provide a list of installed vscode plugins in README
- vscode: Increase default font size (zoom level)
- iterm: Update settings
- iterm: Allow clipboard access
