### PR TITLE
vscode: Show status bar in zen mode

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -54,6 +54,7 @@
         "jupyter-notebook": "left"
     },
     "zenMode.centerLayout": false,
+    "zenMode.hideStatusBar": false,
     "[html]": {
         "editor.defaultFormatter": "vscode.html-language-features"
     },


### PR DESCRIPTION
This is useful to see the current line length and the vim search string
when in zen mode.