### PR TITLE
Install openssl 1.1 via brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install brew: https://brew.sh/
 
 Install necessary tools with brew:
 ```bash
-brew install coreutils direnv git hub node python@3.10 ruby tig tmux tree vim zsh
+brew install coreutils direnv git hub node python@3.10 ruby tig tmux tree vim zsh openssl@1.1
 ```
 
 Clone this repository

--- a/zsh/.exports
+++ b/zsh/.exports
@@ -8,6 +8,8 @@ export PATH=/Applications/Visual\ Studio\ Code.app/Contents/Resources/app/bin:${
 export PATH=/opt/local/libexec/gnubin:${PATH}
 # Add MacPorts to path
 export PATH=/opt/local/bin:~/bin:${PATH}
+# Add brew installed OpenSSL to path
+export PATH=/usr/local/opt/openssl@1.1/bin:${PATH}
 # Add brew installed python to path
 export PATH=/opt/homebrew/opt/python@3.10/bin:/usr/local/opt/python@3.10/bin:${PATH}
 # Add brew installed ruby to path


### PR DESCRIPTION
The OpenSSL version provided by Mac OS is quite outdated. Use brew to
install a newer version.