### PR TITLE
macos: Don't set mouse pointer speed via osxdefaults

### DIFF
--- a/.osxdefaults
+++ b/.osxdefaults
@@ -23,15 +23,6 @@ defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
 # Four-letter codes for the other view modes: `icnv`, `clmv`, `Flwv`
 defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
 
-# =====================
-# === Mouse pointer ===
-# =====================
-
-# Set mouse pointer speed
-# NOTE: This needs a log off/on or restart to take effect
-defaults write -g com.apple.mouse.scaling 3
-
-
 # ============
 # === Dock ===
 # ============


### PR DESCRIPTION
It looks like the configuration via the Settings UI in Mac OS is now
sufficient, so there is no need to set anything beside that.