### PR TITLE
Use exa instead of colorls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install brew: https://brew.sh/
 
 Install necessary tools with brew:
 ```bash
-brew install coreutils direnv git hub node python@3.10 ruby tig tmux tree vim zsh openssl@1.1
+brew install coreutils exa direnv git hub node python@3.10 ruby tig tmux tree vim zsh openssl@1.1
 ```
 
 Clone this repository
@@ -26,10 +26,6 @@ ln -s ~/.dotfiles/tmux/.tmux.conf ~/.tmux.conf
 ln -s ~/.dotfiles/vim/.vimrc ~/.vimrc
 ```
 
-Install colorls via ruby/gem
-```bash
-gem install colorls
-```
 ## ZSH
 
 Install oh-my-zsh: https://ohmyz.sh/

--- a/bin/dotfiles.sh
+++ b/bin/dotfiles.sh
@@ -64,10 +64,6 @@ sub_update() {
     npm install npm -g
     npm update -g
 
-    # Update ruby/gem
-    echo "Updating rub/gem..."
-    sudo gem update --system -n /usr/local/bin
-
     # Update all pipx packages
     echo "Updating pipx packages..."
     pipx upgrade-all

--- a/zsh/.aliases
+++ b/zsh/.aliases
@@ -1,5 +1,6 @@
-#alias ls='colorls --gs'
-alias ll='colorls -lA --gs'
+# We only define an alias for 'll', but keep the default 'ls' command. Otherwise
+# we end up with a lot of errors when exa is not installed (yet).
+alias ll='exa --long --all --icons --git'
 alias ptg='git push origin HEAD:refs/for/master'
 alias weekly="git log --oneline --author 'Felix' --since=1.weeks --no-merges"
 alias sourcetree='open -a SourceTree ./'


### PR DESCRIPTION
Exa[1] is a replacement for ls and built in rust. It is also shipped
with brew on Mac OS so there is no need or additional requirements like
ruby or gem (like colorls).

[1]: https://github.com/ogham/exa