### PR TITLE
Switch to eza

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install brew: https://brew.sh/
 
 Install necessary tools with brew:
 ```bash
-brew install coreutils exa direnv git hub node python@3.10 ruby tig tmux tree vim zsh openssl@1.1
+brew install coreutils eza direnv git hub node python@3.10 ruby tig tmux tree vim zsh openssl@1.1
 ```
 
 Clone this repository

--- a/zsh/.aliases
+++ b/zsh/.aliases
@@ -1,6 +1,6 @@
 # We only define an alias for 'll', but keep the default 'ls' command. Otherwise
 # we end up with a lot of errors when exa is not installed (yet).
-alias ll='exa --long --all --icons --git'
+alias ll='eza --long --all --icons --git'
 alias ptg='git push origin HEAD:refs/for/master'
 alias weekly="git log --oneline --author 'Felix' --since=1.weeks --no-merges"
 alias sourcetree='open -a SourceTree ./'


### PR DESCRIPTION
I just found out that exa is not maintained anymore and one should
switch to eza instead [[1]](https://github.com/ogham/exa/commit/fb05c421ae98e076989eb6e8b1bcf42c07c1d0fe).