### PR TITLE
vscode: Hide command center (search field on top)

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -58,4 +58,5 @@
     "[html]": {
         "editor.defaultFormatter": "vscode.html-language-features"
     },
+    "window.commandCenter": false,
 }


### PR DESCRIPTION
This takes up a lot of space and doesn't provide any benefit over using
cmd+p or shift+cmd+p.