### PR TITLE
Install python3.11 via brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install brew: https://brew.sh/
 
 Install necessary tools with brew:
 ```bash
-brew install coreutils eza direnv git hub node python@3.10 ruby tig tmux tree vim zsh openssl@1.1
+brew install coreutils eza direnv git hub node python@3.11 ruby tig tmux tree vim zsh openssl@1.1
 ```
 
 Clone this repository

--- a/zsh/.exports
+++ b/zsh/.exports
@@ -8,8 +8,6 @@ export PATH=/Applications/Visual\ Studio\ Code.app/Contents/Resources/app/bin:${
 export PATH=/opt/local/libexec/gnubin:${PATH}
 # Add brew installed OpenSSL to path
 export PATH=/usr/local/opt/openssl@1.1/bin:${PATH}
-# Add brew installed python to path
-export PATH=/opt/homebrew/opt/python@3.10/bin:/usr/local/opt/python@3.10/bin:${PATH}
 # Add .dotfiles/scripts to path
 export PATH=~/.dotfiles/bin:${PATH}
 # Add pipx to path


### PR DESCRIPTION
There is also no need to add the python installation to the path as this
is already done by brew. I think I needed this after switching to the M1
mac in the first place, but maybe this is now included in brew directly.