### PR TITLE
vscode: Migrate to black and flake8 extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ ln -s ~/.dotfiles/vscode/keybindings.json ~/Library/Application\ Support/Code/Us
 
 This is a list of plugins, I've currently installed in vscode:
 
+- Black Formatter
+- Flake8
 - Docker
 - GitLens
 - Jupyter

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -10,6 +10,7 @@
         "editor.defaultFormatter": "vscode.json-language-features"
     },
     "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.rulers": [79, 90],
     },
     "editor.bracketPairColorization.enabled": true,
@@ -26,11 +27,7 @@
     "gitlens.defaultDateSource": "committed",
     "outline.showVariables": false,
     "outline.showModules": false,
-    "python.formatting.provider": "black",
-    "python.formatting.blackPath": "~/.local/bin/black",
     "python.languageServer": "Pylance",
-    "python.linting.flake8Enabled": true,
-    "python.linting.flake8Path": "~/.local/bin/flake8",
     "prettier.jsxSingleQuote": true,
     "search.showLineNumbers": true,
     "vim.statusBarColorControl": true,


### PR DESCRIPTION
See guide: https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions