### PR TITLE
tig: Use smart-case search

### DIFF
--- a/tig/.tigrc
+++ b/tig/.tigrc
@@ -1,8 +1,17 @@
+#
+# General
+#
+
+# Make search case insensitive as long as no uppercase letter is present in the
+# search string.
+set ignore-case = smart-case
+
+
 # Do not read Git's color setting.
 #set git-colors = yes
 
 #
-# Color settings
+# Color schema
 #
 
 # general


### PR DESCRIPTION
By default, tig uses case sensitive search, which can be quite annoying
as you often don't know if a word is written with a capital letter or
not.