### PR TITLE
macos: Remove autocorrection default setting

### DIFF
--- a/.osxdefaults
+++ b/.osxdefaults
@@ -55,19 +55,11 @@ cur_user=`whoami`
 sudo -u ${cur_user} defaults write /Users/${cur_user}/Library/Preferences/ByHost/com.apple.controlcenter.plist BatteryShowPercentage -bool true
 
 
-# ==========================
-# === macOS Applications ===
-# ==========================
-
-# Disable spellchecking and auto correction in notes app
-defaults write com.apple.notes NSAutomaticSpellingCorrectionEnabled -bool false
-
-
 # ============================================
 # === Kill applications to enable settings ===
 # ============================================
 
-for app in "Finder" "Dock" "Notes"; do
+for app in "Finder" "Dock"; do
     echo "Killing ${app} to enable settings ..."
     killall "${app}"
 done


### PR DESCRIPTION
This doesn't work as expected as auto-correction is always re-enabled
when starting the Notes app. However, in the meantime I found the
setting in the UI to disable that for now.