### PR TITLE
vscode: Don't show any tabs in zen mode

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -52,6 +52,7 @@
     },
     "zenMode.centerLayout": false,
     "zenMode.hideStatusBar": false,
+    "zenMode.showTabs": "none",
     "[html]": {
         "editor.defaultFormatter": "vscode.html-language-features"
     },


### PR DESCRIPTION
Zen mode looks kind of messy with a lot of tabs open. Usually only the
open tab was visible, but it looks like the default was changed some
time ago to show all tabs (like in normal mode).

However, there is now also the option to completely hide the tabs, which
is what I'm going for.