### PR TITLE
vscode: Set default python interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,11 @@ ln -s ~/.dotfiles/vscode/keybindings.json ~/Library/Application\ Support/Code/Us
 This is a list of plugins, I've currently installed in vscode:
 
 - Black Formatter
+- Container Tools
+- Dev Containers
+- Docker DX
 - Flake8
-- Docker
 - GitLens
-- Jupyter
 - Prettier
 - Pylance
 - Python

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -28,6 +28,7 @@
     "gitlens.defaultDateSource": "committed",
     "outline.showVariables": false,
     "outline.showModules": false,
+    "python.defaultInterpreterPath": "${workspaceFolder}/.tox/dev/bin/python",
     "python.languageServer": "Pylance",
     "prettier.jsxSingleQuote": true,
     "search.showLineNumbers": true,


### PR DESCRIPTION
Also update the VS Code Plugin list in the README.md file.