### PR TITLE
atuin: Use "session" filter when opening atuin via arrow-up key

### DIFF
--- a/atuin/config.toml
+++ b/atuin/config.toml
@@ -1,3 +1,8 @@
 # Open command in edit mode rather than executing it directly when selected
 # from the history.
 enter_accept = false
+
+# Use "session" filter when opening atuin via "arrow up" key to get more of
+# the "re-run last command" functionality while keeping atuins search/filter
+# capabilities.
+filter_mode_shell_up_key_binding = "session"


### PR DESCRIPTION
This feels a little more like the "repeat last command", and still
allows to use atuins filter/search capabilities.