### PR TITLE
atuin: Directly run commands when selected from history

### DIFF
--- a/atuin/config.toml
+++ b/atuin/config.toml
@@ -1,6 +1,6 @@
-# Open command in edit mode rather than executing it directly when selected
-# from the history.
-enter_accept = false
+# Setting this to false will open a command in edit mode rather than
+# executing it directly when selected from the history.
+enter_accept = true
 
 # Use "session" filter when opening atuin via "arrow up" key to get more of
 # the "re-run last command" functionality while keeping atuins search/filter


### PR DESCRIPTION
It took me a while to get used to it, but now I think it's much more
convenient like this. A command can still be opened in edit mode by
pressing arrow-right or tab.