### PR TITLE
Revert: "vscode: Use vim settings from ~/.vimrc file"

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -52,7 +52,6 @@
     "workbench.editor.wrapTabs": true,
     "workbench.editor.tabSizing": "shrink",
     "workbench.editor.decorations.badges": false,
-    "vim.vimrc.enable": true,
     "vsicons.dontShowNewVersionMessage": true,
     "notebook.cellToolbarLocation": {
         "default": "right",


### PR DESCRIPTION
Using the vimrc fails breaks some use cases with the vim plugin in
vscode. I don't feel like debugging this now, so let's just revert this
and play around with it some other time.